### PR TITLE
fix: pin test time to avoid DST-related calendar test failures

### DIFF
--- a/tests/Unit/Actions/Pages/Calendar/ListCalendarEventTest.php
+++ b/tests/Unit/Actions/Pages/Calendar/ListCalendarEventTest.php
@@ -24,6 +24,7 @@ mutates(CalendarsListPage::class);
 
 describe('List Calendar CalendarEvent Page', function (): void {
     beforeEach(function (): void {
+        Date::setTestNow(Date::create(2026, 1, 15, 10, 0, 0, 'UTC'));
 
         $this->seed(RoleSeeder::class);
         $this->user = User::factory()->create();
@@ -59,6 +60,10 @@ describe('List Calendar CalendarEvent Page', function (): void {
                 'role'   => CalendarEventRoleEnum::HOST,
                 'colour' => CalendarEventColoursEnum::BLUE->value,
             ]);
+    });
+
+    afterEach(function (): void {
+        Date::setTestNow();
     });
 
     it('uses provided date from request', function (): void {


### PR DESCRIPTION
## Що пофікшено

Виправлено **8 тестів** у файлі `ListCalendarEventTest.php`, які почали падати через перехід на літній час (DST — Daylight Saving Time).

### Які тести падали

Всі 8 тестів стосувались відображення подій календаря в різних часових зонах (`Europe/Kyiv`, `America/New_York`). Наприклад:
- Очікувалось `'9PM'` — отримували `'10PM'` (Europe/Kyiv)
- Очікувалось `'2PM'` — отримували `'3PM'` (America/New_York)
- Очікувалось `'2:00 AM'` — отримували `'3:00 AM'` (America/New_York)

## Причина поломки

### Як працює DST

Daylight Saving Time (перехід на літній/зимній час) — це коли годинники переводять на +1 годину навесні:
- **Europe/Kyiv**: 29 березня 2026, UTC+2 → UTC+3
- **America/New_York**: 8 березня 2026, UTC-5 → UTC-4

### Чому тести зламались саме 2 березня 2026

Тести використовували `Date::today()` для обчислення дат подій:

```php
Date::today()->endOfMonth()->endOfWeek()
```

Ця конструкція бере **поточний місяць**, знаходить **кінець місяця** (31 березня) і потім **кінець тижня** (неділю) — що дає **5 квітня 2026**.

5 квітня — це вже **після** переходу на літній час в обох часових зонах. Тому подія, створена з часом `19:59 UTC`, конвертувалась так:

| Зона | Зимовий час (очікуваний) | Літній час (фактичний) |
|------|--------------------------|------------------------|
| Europe/Kyiv | 19:59 + 2 = 21:59 (9PM) | 19:59 + 3 = 22:59 (10PM) |
| America/New_York | 19:59 - 5 = 14:59 (2PM) | 19:59 - 4 = 15:59 (3PM) |

Assertions в тестах очікували зимовий час, а отримували літній — звідси розбіжність на 1 годину.

### Чому Weekly View тести не падали

Тести для тижневого виду вже використовували `Date::setTestNow(Date::create(2025, 12, 20...))` — фіксовану дату в грудні 2025, де DST-переходів немає. Саме цей підхід і потрібно було поширити на всі тести.

## Що зроблено

### 1. Додано `Date::setTestNow()` в `beforeEach`

```php
beforeEach(function (): void {
    Date::setTestNow(Date::create(2026, 1, 15, 10, 0, 0, 'UTC'));
    // ... решта setup
});
```

**Чому 15 січня 2026:**
- `endOfMonth()` → 31 січня → `endOfWeek()` → 1 лютого (неділя)
- В січні-лютому обидві зони (`Europe/Kyiv` і `America/New_York`) гарантовано в зимовому часі
- Жодного DST-переходу між 15 січня і 1 лютого

### 2. Додано `afterEach` для очищення

```php
afterEach(function (): void {
    Date::setTestNow();
});
```

Це скидає "заморожений" час після кожного тесту, щоб не було **test pollution** (коли стан одного тесту впливає на інший).

## Як уникнути подібного в майбутньому

1. **Завжди фіксуй час в тестах через `Date::setTestNow()`** — якщо тест залежить від поточної дати, він рано чи пізно зламається при зміні сезону або місяця
2. **Вибирай "безпечні" дати** — січень або лютий, коли всі основні часові зони в зимовому часі, і жоден `endOfMonth()->endOfWeek()` не перетинає DST-перехід
3. **Додавай `afterEach` з очисткою** — завжди скидай `setTestNow()` після тестів
4. **Не довіряй `Date::today()`** в тестах — це завжди потенційне джерело flaky-тестів

## Верифікація

- [x] Всі 20 тестів у `ListCalendarEventTest.php` проходять (207 assertions)
- [x] Весь тест-сьют проходить: 1053 passed, 7 skipped, 0 failures