### PR TITLE
Feature/159 mentor list with booking page

### DIFF
--- a/app/Actions/MentorPrograms/StoreMentorProgramPage.php
+++ b/app/Actions/MentorPrograms/StoreMentorProgramPage.php
@@ -22,6 +22,6 @@ class StoreMentorProgramPage
             'mentor_id' => Auth::id(),
         ]);
 
-        return Inertia::location(route('mentor-program.create'));
+        return Inertia::location(route('mentor-program.list'));
     }
 }

--- a/app/Actions/Pages/Calendar/ConfirmedCalendarEventsListPage.php
+++ b/app/Actions/Pages/Calendar/ConfirmedCalendarEventsListPage.php
@@ -7,6 +7,7 @@ namespace App\Actions\Pages\Calendar;
 use App\Enums\CalendarEventStatusEnum;
 use App\Models\CalendarEvent;
 use App\Models\MentorProgram;
+use Illuminate\Support\Collection;
 use Inertia\Inertia;
 use Inertia\Response;
 use Lorisleiva\Actions\Concerns\AsController;
@@ -31,9 +32,12 @@ class ConfirmedCalendarEventsListPage
 
         $events = $query->orderBy('start_date_time')->get();
 
-        $grouped = $events->groupBy(
-            fn (CalendarEvent $event): string => $event->mentorProgram->name ?? 'Unknown Program'
-        );
+        $grouped = $events
+            ->groupBy(fn (CalendarEvent $event): int => $event->mentor_program_id ?? 0)
+            ->map(fn (Collection $group): array => [
+                'name'   => $group->first()->mentorProgram->name ?? 'Unknown Program',
+                'events' => $group->values(),
+            ]);
 
         return Inertia::render('Calendar/ListConfirmedCalendarEventsPage', [
             'locale'         => app()->getLocale(),

--- a/app/Actions/Pages/Calendar/ConfirmedCalendarEventsListPage.php
+++ b/app/Actions/Pages/Calendar/ConfirmedCalendarEventsListPage.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Pages\Calendar;
+
+use App\Enums\CalendarEventStatusEnum;
+use App\Models\CalendarEvent;
+use App\Models\MentorProgram;
+use Inertia\Inertia;
+use Inertia\Response;
+use Lorisleiva\Actions\Concerns\AsController;
+
+class ConfirmedCalendarEventsListPage
+{
+    use AsController;
+
+    public function handle(?MentorProgram $mentorProgram = null): Response
+    {
+        $user = auth()->user();
+
+        $query = $user->calendarEvents()
+            ->where('status', CalendarEventStatusEnum::CONFIRMED->value)
+            ->where('start_date_time', '>=', now());
+
+        if ($mentorProgram instanceof MentorProgram) {
+            $query->where('mentor_program_id', $mentorProgram->getKey());
+        }
+
+        $query->with(['mentorProgram:id,name']);
+
+        $events = $query->orderBy('start_date_time')->get();
+
+        $grouped = $events->groupBy(
+            fn (CalendarEvent $event): string => $event->mentorProgram->name ?? 'Unknown Program'
+        );
+
+        return Inertia::render('Calendar/ListConfirmedCalendarEventsPage', [
+            'locale'         => app()->getLocale(),
+            'calendarEvents' => $grouped,
+        ]);
+    }
+}

--- a/app/Actions/Pages/Profile/ListMentorProfilePage.php
+++ b/app/Actions/Pages/Profile/ListMentorProfilePage.php
@@ -11,7 +11,9 @@ use App\Filters\RatingFilter;
 use App\Filters\TagLanguagesFilter;
 use App\Filters\TagStacksFilter;
 use App\Models\MentorProfile;
-use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use App\Models\User;
+use Inertia\Inertia;
+use Inertia\Response;
 use Lorisleiva\Actions\Concerns\AsController;
 use Spatie\QueryBuilder\AllowedFilter;
 use Spatie\QueryBuilder\QueryBuilder;
@@ -20,13 +22,16 @@ class ListMentorProfilePage
 {
     use AsController;
 
-    /**
-     * @return LengthAwarePaginator<int, MentorProfile>
-     */
-    public function handle(): LengthAwarePaginator
+    public function handle(): Response
     {
-        return QueryBuilder::for(MentorProfile::class)
-            ->allowedIncludes(['mentorPrograms', 'mentorTags'])
+        $mentors = QueryBuilder::for(MentorProfile::class)
+            ->with([
+                'user.profile',
+                'currency',
+                'user.mentorPrograms' => fn (mixed $query) => $query
+                    ->where('is_main', true)
+                    ->select(['id', 'mentor_id', 'slug']),
+            ])
             ->allowedFilters([
                 'title',
                 'description',
@@ -45,7 +50,22 @@ class ListMentorProfilePage
                 'rate',
                 'experience_started_at',
             ])
-            ->paginate()
-            ->appends(request()->query());
+            ->paginate(User::DEFAULT_MENTOR_PAGE_PAGINATION)
+            ->appends(request()->query())
+            ->through(fn (MentorProfile $mentor): array => [
+                'title'           => $mentor->title,
+                'description'     => $mentor->description,
+                'rate'            => $mentor->rate,
+                'currency'        => ['symbol' => $mentor->currency?->symbol],
+                'userSlug'        => $mentor->user->slug,
+                'userName'        => $mentor->user->profile?->name,
+                'userAvatar'      => $mentor->user->profile?->avatar,
+                'mainProgramSlug' => $mentor->user->mentorPrograms
+                    ->where('isMain', '=', true)->first()?->slug,
+            ]);
+
+        return Inertia::render('Profile/MentorListPage', [
+            'mentors' => $mentors,
+        ]);
     }
 }

--- a/app/Actions/Pages/Profile/ListMentorProfilePage.php
+++ b/app/Actions/Pages/Profile/ListMentorProfilePage.php
@@ -30,8 +30,7 @@ class ListMentorProfilePage
                 'user.profile',
                 'currency',
                 'user.mentorPrograms' => fn (mixed $query) => $query
-                    ->where('is_main', true)
-                    ->select(['id', 'mentor_id', 'slug']),
+                    ->select(['id', 'mentor_id', 'slug', 'is_main']),
             ])
             ->allowedFilters([
                 'title',
@@ -62,7 +61,7 @@ class ListMentorProfilePage
                 'userName'        => $mentor->user->profile->name,
                 'userAvatar'      => $mentor->user->profile->avatar,
                 'mainProgramSlug' => $mentor->user->mentorPrograms
-                    ->where('isMain', '=', true)->first()?->slug,
+                    ->where('is_main', '=', true)->first()?->slug,
             ]);
 
         return Inertia::render('Profile/MentorListPage', [

--- a/app/Actions/Pages/Profile/ListMentorProfilePage.php
+++ b/app/Actions/Pages/Profile/ListMentorProfilePage.php
@@ -24,6 +24,7 @@ class ListMentorProfilePage
 
     public function handle(): Response
     {
+        // @phpstan-ignore method.notFound (Larastan's with() return type narrows to Builder, losing QueryBuilder type)
         $mentors = QueryBuilder::for(MentorProfile::class)
             ->with([
                 'user.profile',
@@ -58,8 +59,8 @@ class ListMentorProfilePage
                 'rate'            => $mentor->rate,
                 'currency'        => ['symbol' => $mentor->currency?->symbol],
                 'userSlug'        => $mentor->user->slug,
-                'userName'        => $mentor->user->profile?->name,
-                'userAvatar'      => $mentor->user->profile?->avatar,
+                'userName'        => $mentor->user->profile->name,
+                'userAvatar'      => $mentor->user->profile->avatar,
                 'mainProgramSlug' => $mentor->user->mentorPrograms
                     ->where('isMain', '=', true)->first()?->slug,
             ]);

--- a/app/Enums/MentorSessionDurationOptionsEnum.php
+++ b/app/Enums/MentorSessionDurationOptionsEnum.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum MentorSessionDurationOptionsEnum: int
+{
+    case FIFTEEN_MINUTES = 15;
+    case HALF_HOUR = 30;
+    case FOURTY_FIVE_MINUTES = 45;
+    case HOUR = 60;
+    case ONE_AND_HALF_HOURS = 90;
+    case TWO_HOURS = 120;
+
+    /**
+     * @return list<string>
+     */
+    public static function names(): array
+    {
+        return array_column(self::cases(), 'name');
+    }
+
+    /**
+     * @return list<int>
+     */
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+}

--- a/app/Enums/MentorSessionTypeEnum.php
+++ b/app/Enums/MentorSessionTypeEnum.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum MentorSessionTypeEnum: string
+{
+    case VIDEO_SESSION = 'Video Session';
+    case VOICE_SESSION = 'Voice Session';
+    case CODE_REVIEW = 'Code Review';
+
+    /**
+     * @return list<string>
+     */
+    public static function names(): array
+    {
+        return array_column(self::cases(), 'name');
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+}

--- a/app/Http/Resources/MentorProfilePageResource.php
+++ b/app/Http/Resources/MentorProfilePageResource.php
@@ -66,7 +66,7 @@ class MentorProfilePageResource extends JsonResource
             'reviews'           => $user->mentorReviews->count(),
             'experience'        => $years.' '.trans_choice('messages.years', $years, ['count' => $years]),
             'mentiCount'        => $user->mentorSessions->unique('menti_id')->count(),
-            'mainProgramSlug'   => $user->mentorPrograms->where('isMain', '=', true)->first()?->slug,
+            'mainProgramSlug'   => $user->mentorPrograms->where('is_main', '=', true)->first()?->slug,
         ];
     }
 

--- a/app/Http/Resources/MentorProfilePageResource.php
+++ b/app/Http/Resources/MentorProfilePageResource.php
@@ -54,18 +54,19 @@ class MentorProfilePageResource extends JsonResource
         $years = (int) $user->mentorProfile?->experience_started_at?->diffInYears(now()) ?? 0;
 
         return [
-            'name'        => mb_trim($user->profile->name.' '.$user->profile->last_name),
-            'avatar'      => $user->profile->avatar ?: UserProfile::DEFAULT_AVATAR_URL,
-            'title'       => $user->mentorProfile?->title,
-            'description' => $user->mentorProfile?->description,
-            'rate'        => $user->mentorProfile?->rate,
-            'currency'    => $user->mentorProfile?->currency?->symbol,
-            'languages'   => $user->mentorProfile?->languages->pluck('tag')->toArray(),
-            'stacks'      => $user->mentorProfile?->stacks->pluck('tag')->toArray(),
-            'rating'      => round($user->rating, 1),
-            'reviews'     => $user->mentorReviews->count(),
-            'experience'  => $years.' '.trans_choice('messages.years', $years, ['count' => $years]),
-            'mentiCount'  => $user->mentorSessions->unique('menti_id')->count(),
+            'name'              => mb_trim($user->profile->name.' '.$user->profile->last_name),
+            'avatar'            => $user->profile->avatar ?: UserProfile::DEFAULT_AVATAR_URL,
+            'title'             => $user->mentorProfile?->title,
+            'description'       => $user->mentorProfile?->description,
+            'rate'              => $user->mentorProfile?->rate,
+            'currency'          => $user->mentorProfile?->currency?->symbol,
+            'languages'         => $user->mentorProfile?->languages->pluck('tag')->toArray(),
+            'stacks'            => $user->mentorProfile?->stacks->pluck('tag')->toArray(),
+            'rating'            => round($user->rating, 1),
+            'reviews'           => $user->mentorReviews->count(),
+            'experience'        => $years.' '.trans_choice('messages.years', $years, ['count' => $years]),
+            'mentiCount'        => $user->mentorSessions->unique('menti_id')->count(),
+            'mainProgramSlug'   => $user->mentorPrograms->where('isMain', '=', true)->first()?->slug,
         ];
     }
 

--- a/app/Models/MentorProgram.php
+++ b/app/Models/MentorProgram.php
@@ -34,6 +34,7 @@ class MentorProgram extends Model
         'mentor_id',
         'name',
         'slug',
+        'is_main',
         'description',
         'cost',
         'currency_id',
@@ -122,6 +123,7 @@ class MentorProgram extends Model
     protected function casts(): array
     {
         return [
+            'is_main'    => 'boolean',
             'start_time' => 'datetime',
             'end_time'   => 'datetime',
         ];

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -87,6 +87,7 @@ class User extends Authenticatable implements HasMedia, HasName, MustVerifyEmail
     protected $visible = [
         'id',
         'username',
+        'slug',
         'email',
         'created_at',
         'updated_at',

--- a/app/Observers/MentorProgramObserver.php
+++ b/app/Observers/MentorProgramObserver.php
@@ -9,6 +9,20 @@ use Illuminate\Support\Str;
 
 class MentorProgramObserver
 {
+    public function created(MentorProgram $mentorProgram): void
+    {
+        $isFirstProgram = ! MentorProgram::query()
+            ->where('mentor_id', $mentorProgram->mentor_id)
+            ->where('id', '!=', $mentorProgram->getKey())
+            ->where('is_main', true)
+            ->exists();
+
+        if ($isFirstProgram) {
+            $mentorProgram->is_main = true;
+            $mentorProgram->saveQuietly();
+        }
+    }
+
     public function saved(MentorProgram $mentorProgram): void
     {
         if (empty($mentorProgram->slug) && ! empty($mentorProgram->name)) {

--- a/database/factories/MentorProgramFactory.php
+++ b/database/factories/MentorProgramFactory.php
@@ -28,9 +28,15 @@ class MentorProgramFactory extends Factory
                 ->value('id'),
             'name'        => fake()->sentence(3),
             'slug'        => fake()->slug(),
+            'is_main'     => false,
             'description' => fake()->sentence(20),
             'cost'        => fake()->randomFloat(2, 10, 1000),
             'currency_id' => Currency::query()->inRandomOrder()->value('id') ?? Currency::factory(),
         ];
+    }
+
+    public function main(): static
+    {
+        return $this->state(['is_main' => true]);
     }
 }

--- a/database/migrations/2026_03_13_132802_add_is_main_to_mentor_programs_table.php
+++ b/database/migrations/2026_03_13_132802_add_is_main_to_mentor_programs_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('mentor_programs', function (Blueprint $table): void {
+            $table->boolean('is_main')->default(false)->after('slug');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('mentor_programs', function (Blueprint $table): void {
+            $table->dropColumn('is_main');
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -19,6 +19,7 @@ final class DatabaseSeeder extends Seeder
             SuperAdminSeeder::class,
             CoachSeeder::class,
             MentorTagSeeder::class,
+            MentorProfileSeeder::class,
             MentorProgramSeeder::class,
             CalendarEventSeeder::class,
             MentorReviewSeeder::class,

--- a/database/seeders/MentorProfileSeeder.php
+++ b/database/seeders/MentorProfileSeeder.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Enums\RoleEnum;
+use App\Models\MentorProfile;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+class MentorProfileSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        User::query()
+            ->role(RoleEnum::MENTOR->value)
+            ->whereDoesntHave('mentorProfile')
+            ->each(function (User $mentor): void {
+                MentorProfile::factory()->create(['user_id' => $mentor->getKey()]);
+            });
+    }
+}

--- a/docs/CALENDAR.md
+++ b/docs/CALENDAR.md
@@ -1,0 +1,221 @@
+# Calendar Booking System Documentation
+
+## Overview
+
+The calendar booking system allows mentees to book sessions with mentors based
+on available time slots. The system handles timezone conversions, schedule
+exclusions, and session duration management.
+
+## Key Concepts
+
+### 4.1 Future Dates Only
+
+Events can only be created for future dates. The system enforces this through
+validation rules:
+
+- `fromDate` must be today or a future date
+- `toDate` must be on or after `fromDate`
+- The maximum booking window is defined by
+  `CalendarEvent::MAXIMUM_NUMBER_OF_MONTHS_EVENT_CAN_BE_SET` (6 months)
+
+### 4.2 MentorProgram Connection
+
+Every calendar event associated with mentor sessions requires a valid
+`mentor_program_id`:
+
+- The `mentor_program_id` links the event to a specific mentorship program
+- Only the mentor who owns the program can create events for it
+- Events without a `mentor_program_id` are treated as personal calendar events
+
+### 4.3 Event Status Flow
+
+Calendar events follow a specific status workflow:
+
+```
+PENDING_MENTOR_CONFIRMATION -> CONFIRMED -> FINISHED
+                           \-> CANCELLED
+```
+
+**Status Definitions:**
+
+| Status                        | Description                                           |
+| ----------------------------- | ----------------------------------------------------- |
+| `PENDING_MENTOR_CONFIRMATION` | Event created by mentee, awaiting mentor confirmation |
+| `PENDING_PAYMENT`             | Event confirmed but payment pending                   |
+| `CONFIRMED`                   | Event confirmed by all parties                        |
+| `FINISHED`                    | Event has been completed                              |
+| `CANCELLED`                   | Event was cancelled                                   |
+
+**Status Transitions:**
+
+1. When a mentee books a slot, the event is created with
+   `PENDING_MENTOR_CONFIRMATION` status
+2. When the mentor confirms, status changes to `CONFIRMED`
+3. A `MentorSession` is automatically created when status changes to `CONFIRMED`
+4. Completed events are marked as `FINISHED`
+5. Either party can cancel, changing status to `CANCELLED`
+
+**Restrictions:**
+
+- `FINISHED` events cannot be edited or deleted
+- `CANCELLED` events cannot be edited or deleted
+- Only `CONFIRMED` and `PENDING_MENTOR_CONFIRMATION` events can be modified
+
+### 4.4 Session Duration
+
+Each mentor program has a configurable `session_duration` setting (in minutes):
+
+- Default session duration options: 30, 45, 60, 90, 120 minutes
+- Available slots are automatically split based on session duration
+- The `SplitSlotsPerSessionDuration` service handles slot splitting
+
+**How it works:**
+
+1. Available time blocks are calculated from mentor's schedule
+2. Existing events are excluded from available time
+3. Remaining time is split into slots matching the program's session duration
+
+### 4.5 Minimum Pre-booking Time
+
+The `minimum_pre_booking_time` setting from mentor profile controls how far in
+advance bookings can be made:
+
+- Stored in minutes on the mentor's profile
+- Default: 0 (no minimum)
+- Example: Setting to 1440 (24 hours) means mentees must book at least 1 day in
+  advance
+
+## Core Services
+
+### BookingCalendarEventsService
+
+Main service for generating available booking slots:
+
+```php
+$service = new BookingCalendarEventsService(
+    $selectedDate,      // Carbon date to display
+    $mentor,            // User model (mentor)
+    $timezone,          // Client timezone
+    $excludeSchedule,   // Whether to apply mentor's schedule
+    $mentorProgram      // MentorProgram model
+);
+
+$result = $service->getFormattedMonthAvailableSlots();
+// Returns: ['calendarSlots' => [...], 'hasEventsBefore' => bool, 'hasEventsAfter' => bool]
+```
+
+### AvailableCalendarEventsSlotsService
+
+Calculates raw available time slots:
+
+- Excludes time occupied by existing events
+- Handles multi-day events
+- Respects timezone conversions
+
+### ExcludeUserScheduleSchemeService
+
+Filters available slots based on mentor's working schedule:
+
+- Supports multiple working periods per day
+- Handles day-off dates
+- Performs timezone conversions for schedule matching
+
+### SplitSlotsPerSessionDuration
+
+Splits available time blocks into bookable slots:
+
+- Groups slots by date
+- Handles slots spanning midnight
+- Respects session duration from mentor program
+
+## CalendarEventObserver
+
+Automatically creates `MentorSession` records when events are confirmed:
+
+**Triggers when:**
+
+- Event status changes from any status TO `CONFIRMED`
+- Event has a valid `mentor_program_id`
+- Event has both HOST and PARTICIPANT users attached
+
+**Creates MentorSession with:**
+
+- `mentor_id`: From user with HOST role
+- `menti_id`: From user with PARTICIPANT role
+- `date`: From event's `start_date_time`
+- `mentor_program_id`: From event's `mentor_program_id`
+
+## Timezone Handling
+
+The system stores all times in UTC and converts for display:
+
+1. Events are stored with UTC timestamps in `start_date_time` and
+   `end_date_time`
+2. User's timezone preference is stored in their profile
+3. Available slots are calculated and returned in the requested timezone
+4. Schedule times are stored as local times and converted when checking
+   availability
+
+## Concurrent Booking Prevention
+
+The system prevents double-booking:
+
+1. When confirming an event, the system checks for overlapping confirmed events
+2. Partial overlaps are blocked (event A: 14:00-15:00, event B: 14:30-15:30)
+3. Adjacent slots are allowed (event A ends at 15:00, event B starts at 15:00)
+4. Events completely inside another are blocked
+
+## Database Schema
+
+### calendar_events
+
+| Column            | Type     | Description                      |
+| ----------------- | -------- | -------------------------------- |
+| id                | bigint   | Primary key                      |
+| title             | string   | Event title                      |
+| status            | string   | Event status (enum)              |
+| start_date_time   | datetime | Start time (UTC)                 |
+| end_date_time     | datetime | End time (UTC)                   |
+| date              | date     | Event date                       |
+| type              | string   | Event type (individual, group)   |
+| web_link          | string   | Meeting link (optional)          |
+| description       | text     | Event description (optional)     |
+| mentor_program_id | bigint   | FK to mentor_programs (nullable) |
+| mentor_session_id | bigint   | FK to mentor_sessions (nullable) |
+
+### calendar_event_user (pivot)
+
+| Column            | Type     | Description                           |
+| ----------------- | -------- | ------------------------------------- |
+| calendar_event_id | bigint   | FK to calendar_events                 |
+| user_id           | bigint   | FK to users                           |
+| role              | string   | User's role (Host, Participant, etc.) |
+| colour            | string   | Display colour                        |
+| confirmed_at      | datetime | When user confirmed                   |
+
+### user_schedules
+
+| Column       | Type   | Description               |
+| ------------ | ------ | ------------------------- |
+| user_id      | bigint | FK to users               |
+| day_of_week  | int    | 1-7 (Monday-Sunday)       |
+| start_time   | time   | Working hours start       |
+| end_time     | time   | Working hours end         |
+| type         | string | WORKING_DAY or DAY_OFF    |
+| day_off_date | date   | Specific date for day off |
+
+## Testing
+
+Run calendar-related tests:
+
+```bash
+# Run all calendar tests
+php artisan test --filter=Calendar
+
+# Run specific service tests
+php artisan test tests/Unit/Services/Calendar/
+
+# Run mutation tests
+./vendor/bin/pest --mutate --class=BookingCalendarEventsService
+./vendor/bin/pest --mutate --class=CalendarEventObserver
+```

--- a/resources/js/Pages/Calendar/ListConfirmedCalendarEventsPage.vue
+++ b/resources/js/Pages/Calendar/ListConfirmedCalendarEventsPage.vue
@@ -1,0 +1,83 @@
+<script setup>
+import { router } from '@inertiajs/vue3';
+
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+
+const props = defineProps({
+  locale: {
+    type: String,
+    default: null,
+  },
+  calendarEvents: {
+    type: Object,
+    default: () => {},
+  },
+});
+
+const openEvent = (calendarEventId) => {
+  router.visit(route('pages.calendar.show', { id: calendarEventId }));
+};
+</script>
+
+<template>
+  <AuthenticatedLayout>
+    <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+      <div class="mb-8 flex items-center justify-between">
+        <div>
+          <h1 class="text-3xl font-bold text-gray-900">
+            Confirmed & Upcoming Events
+          </h1>
+          <p class="mt-2 text-sm text-gray-600">
+            All confirmed sessions scheduled for the future.
+          </p>
+        </div>
+      </div>
+
+      <div
+        v-if="Object.keys(props.calendarEvents).length === 0"
+        class="rounded-lg border border-gray-200 bg-white p-8 text-center text-gray-500 shadow-sm"
+      >
+        No confirmed upcoming events.
+      </div>
+
+      <div class="space-y-4">
+        <div
+          v-for="(events, mentorProgramName) in props.calendarEvents"
+          :key="mentorProgramName"
+          class="rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
+        >
+          <div class="mb-4 flex items-center justify-between">
+            <h2 class="text-lg font-semibold text-gray-900">
+              {{ mentorProgramName }}
+            </h2>
+          </div>
+
+          <div
+            v-for="event in events"
+            :key="event.id"
+            class="rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
+          >
+            <div class="mb-2 flex items-center justify-between">
+              <h3 class="text-base font-semibold text-gray-900">
+                {{ event.title }}
+              </h3>
+              <button
+                type="button"
+                class="inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-xs ring-1 ring-gray-300 ring-inset hover:bg-gray-50"
+                @click="openEvent(event.id)"
+              >
+                View / Edit
+              </button>
+            </div>
+            <p class="text-sm text-gray-600">
+              <span class="font-medium">When:</span>
+              {{ new Date(event.start_date_time).toLocaleString() }}
+              —
+              {{ new Date(event.end_date_time).toLocaleString() }}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </AuthenticatedLayout>
+</template>

--- a/resources/js/Pages/Calendar/ListConfirmedCalendarEventsPage.vue
+++ b/resources/js/Pages/Calendar/ListConfirmedCalendarEventsPage.vue
@@ -15,7 +15,7 @@ const props = defineProps({
 });
 
 const openEvent = (calendarEventId) => {
-  router.visit(route('pages.calendar.show', { calendarEvent: calendarEventId }));
+  router.visit(route('pages.calendar.show', { id: calendarEventId }));
 };
 </script>
 

--- a/resources/js/Pages/Calendar/ListConfirmedCalendarEventsPage.vue
+++ b/resources/js/Pages/Calendar/ListConfirmedCalendarEventsPage.vue
@@ -15,7 +15,7 @@ const props = defineProps({
 });
 
 const openEvent = (calendarEventId) => {
-  router.visit(route('pages.calendar.show', { id: calendarEventId }));
+  router.visit(route('pages.calendar.show', { calendarEvent: calendarEventId }));
 };
 </script>
 
@@ -42,18 +42,18 @@ const openEvent = (calendarEventId) => {
 
       <div class="space-y-4">
         <div
-          v-for="(events, mentorProgramName) in props.calendarEvents"
-          :key="mentorProgramName"
+          v-for="(group, programId) in props.calendarEvents"
+          :key="programId"
           class="rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
         >
           <div class="mb-4 flex items-center justify-between">
             <h2 class="text-lg font-semibold text-gray-900">
-              {{ mentorProgramName }}
+              {{ group.name }}
             </h2>
           </div>
 
           <div
-            v-for="event in events"
+            v-for="event in group.events"
             :key="event.id"
             class="rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
           >

--- a/resources/js/Pages/MentorProgram/CreateOrEdit.vue
+++ b/resources/js/Pages/MentorProgram/CreateOrEdit.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { useForm } from '@inertiajs/vue3';
+import { Link, useForm } from '@inertiajs/vue3';
 import { computed, ref } from 'vue';
 
 import AppModal from '@/Components/AppModal.vue';
@@ -69,9 +69,17 @@ const deleteProgram = () => {
 <template>
   <AuthenticatedLayout>
     <template #header>
-      <h2 class="text-xl leading-tight font-semibold text-gray-800">
-        {{ isEdit ? 'Edit Mentor Program' : 'Create New Mentor Program' }}
-      </h2>
+      <div class="flex items-center justify-between">
+        <h2 class="text-xl leading-tight font-semibold text-gray-800">
+          {{ isEdit ? 'Edit Mentor Program' : 'Create New Mentor Program' }}
+        </h2>
+        <Link
+          :href="route('mentor-program.list')"
+          class="rounded-md bg-white px-2.5 py-1.5 text-sm font-semibold text-gray-900 shadow-xs ring-1 ring-gray-300 ring-inset hover:bg-gray-50"
+        >
+          &larr; Back to Programs
+        </Link>
+      </div>
     </template>
 
     <div class="py-12">

--- a/resources/js/Pages/MentorProgram/ListPage.vue
+++ b/resources/js/Pages/MentorProgram/ListPage.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/vue';
 import { EllipsisVerticalIcon } from '@heroicons/vue/20/solid';
-import { router } from '@inertiajs/vue3';
+import { Link, router } from '@inertiajs/vue3';
 import { ref } from 'vue';
 
 import AppModal from '@/Components/AppModal.vue';
@@ -55,12 +55,20 @@ const deleteProgram = () => {
         <h2 class="text-xl leading-tight font-semibold text-gray-800">
           Mentor Programs
         </h2>
-        <a
-          :href="route('pages.calendar.pending')"
-          class="rounded-md bg-yellow-50 px-2.5 py-1.5 text-sm font-semibold text-gray-900 shadow-xs ring-1 ring-yellow-200 ring-inset hover:bg-yellow-100"
-        >
-          All Pending Events
-        </a>
+        <div class="flex items-center gap-x-3">
+          <a
+            :href="route('pages.calendar.pending')"
+            class="rounded-md bg-yellow-50 px-2.5 py-1.5 text-sm font-semibold text-gray-900 shadow-xs ring-1 ring-yellow-200 ring-inset hover:bg-yellow-100"
+          >
+            All Pending Events
+          </a>
+          <Link
+            :href="route('mentor-program.create')"
+            class="rounded-md bg-indigo-600 px-2.5 py-1.5 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500"
+          >
+            Create Program
+          </Link>
+        </div>
       </div>
     </template>
 
@@ -104,14 +112,6 @@ const deleteProgram = () => {
                     >
 
                     <a
-                      :href="route('pages.mentor.program.book', program.slug)"
-                      class="hidden rounded-md bg-white px-2.5 py-1.5 text-sm font-semibold text-gray-900 shadow-xs ring-1 ring-gray-300 ring-inset hover:bg-gray-50 sm:block"
-                      >Book event<span class="sr-only"
-                        >, {{ program.name }}</span
-                      ></a
-                    >
-
-                    <a
                       :href="route('pages.calendar.pending', program.slug)"
                       :class="[
                         'hidden rounded-md px-2.5 py-1.5 text-sm font-semibold'
@@ -125,8 +125,8 @@ const deleteProgram = () => {
                     </a>
 
                     <a
-                      :href="route('pages.mentor.program.book', program.slug)"
-                      class="hidden rounded-md bg-white px-2.5 py-1.5 text-sm font-semibold text-gray-900 shadow-xs ring-1 ring-gray-300 ring-inset hover:bg-gray-50 sm:block"
+                      :href="route('pages.calendar.confirmed', program.slug)"
+                      class="hidden rounded-md bg-blue-50 px-2.5 py-1.5 text-sm font-semibold text-gray-900 shadow-xs ring-1 ring-blue-200 ring-inset hover:bg-blue-100 sm:block"
                     >
                       Confirmed {{ program.confirmed_events_number }}
                     </a>
@@ -176,40 +176,6 @@ const deleteProgram = () => {
                               Delete<span class="sr-only"
                                 >, {{ program.name }}</span
                               >
-                            </button>
-                          </MenuItem>
-
-                          <MenuItem v-slot="{ active }">
-                            <button
-                              type="button"
-                              :class="[
-                                active ? 'bg-gray-50 outline-hidden' : '',
-                                'block w-full px-3 py-1 text-left text-sm/6 text-gray-900',
-                              ]"
-                              @click="
-                                route('pages.mentor.program.book', program.slug)
-                              "
-                            >
-                              Book Event<span class="sr-only"
-                                >, {{ program.name }}</span
-                              >
-                            </button>
-
-                            <button
-                              type="button"
-                              :class="[
-                                program.pending_events_requests_number === 0 ?
-                                  'bg-green-200 outline-hidden'
-                                : 'bg-red-200 outline-hidden',
-                                'block w-full px-3 py-1 text-left text-sm/6 text-gray-900',
-                              ]"
-                              @click="
-                                route('pages.mentor.program.book', program.slug)
-                              "
-                            >
-                              Need confirmation
-                              {{ program.pending_events_requests_number }}
-                              <span class="sr-only bg-red-300"></span>
                             </button>
                           </MenuItem>
                         </MenuItems>

--- a/resources/js/Pages/Profile/Mentor/Blocks/AvailablePrograms.vue
+++ b/resources/js/Pages/Profile/Mentor/Blocks/AvailablePrograms.vue
@@ -63,11 +63,12 @@ defineProps({
         </div>
       </div>
 
-      <button
-        class="mt-auto w-full rounded-lg bg-blue-600 px-4 py-3 font-medium text-white transition-colors duration-200 hover:bg-blue-700"
+      <a
+        :href="route('pages.mentor.program.book', program.slug)"
+        class="mt-auto block w-full rounded-lg bg-blue-600 px-4 py-3 text-center font-medium text-white transition-colors duration-200 hover:bg-blue-700"
       >
         Book Session
-      </button>
+      </a>
     </div>
   </div>
 </template>

--- a/resources/js/Pages/Profile/Mentor/Blocks/AvailablePrograms.vue
+++ b/resources/js/Pages/Profile/Mentor/Blocks/AvailablePrograms.vue
@@ -1,4 +1,6 @@
 <script setup>
+import {Link} from "@inertiajs/vue3";
+
 defineProps({
   data: {
     type: Object,
@@ -63,12 +65,12 @@ defineProps({
         </div>
       </div>
 
-      <a
+      <Link
         :href="route('pages.mentor.program.book', program.slug)"
         class="mt-auto block w-full rounded-lg bg-blue-600 px-4 py-3 text-center font-medium text-white transition-colors duration-200 hover:bg-blue-700"
       >
         Book Session
-      </a>
+      </Link>
     </div>
   </div>
 </template>

--- a/resources/js/Pages/Profile/Mentor/Blocks/AvailablePrograms.vue
+++ b/resources/js/Pages/Profile/Mentor/Blocks/AvailablePrograms.vue
@@ -1,5 +1,5 @@
 <script setup>
-import {Link} from "@inertiajs/vue3";
+import { Link } from '@inertiajs/vue3';
 
 defineProps({
   data: {

--- a/resources/js/Pages/Profile/Mentor/Blocks/CalendarMentor.vue
+++ b/resources/js/Pages/Profile/Mentor/Blocks/CalendarMentor.vue
@@ -535,6 +535,7 @@ import { GlobeAltIcon } from '@heroicons/vue/16/solid/index.js';
       <GlobeAltIcon class="h-4 w-4 text-gray-500" />
       <p class="ms-2 text-gray-500">Times shows in your local timezone</p>
     </div>
+
     <button
       class="mt-4 w-full rounded-lg bg-blue-600 px-4 py-3 font-medium text-white transition-colors duration-200 hover:bg-blue-700"
     >

--- a/resources/js/Pages/Profile/Mentor/Blocks/TitleProfile.vue
+++ b/resources/js/Pages/Profile/Mentor/Blocks/TitleProfile.vue
@@ -123,11 +123,14 @@ defineProps({
               <BookmarkIcon class="h-5 w-5 fill-none stroke-blue-600" />
               Save Profile
             </button>
-            <button
-              class="rounded-lg bg-blue-600 px-6 py-2 font-medium text-white transition-colors hover:bg-blue-700"
+
+            <a
+              v-if="data.mainProgramSlug"
+              :href="route('pages.mentor.program.book', data.mainProgramSlug)"
+              class="hover:bg-blue-70 rounded-lg bg-blue-600 px-6 py-2 font-medium text-white transition-colors"
             >
               Book Consultation
-            </button>
+            </a>
           </div>
         </div>
       </div>

--- a/resources/js/Pages/Profile/MentorListPage.vue
+++ b/resources/js/Pages/Profile/MentorListPage.vue
@@ -20,7 +20,7 @@ defineProps({
 
         <div class="space-y-6">
           <div
-            v-for="(mentor, index) in mentors.data"
+            v-for="mentor in mentors.data"
             :key="mentor.userSlug"
             class="overflow-hidden rounded-lg bg-white shadow-sm"
           >

--- a/resources/js/Pages/Profile/MentorListPage.vue
+++ b/resources/js/Pages/Profile/MentorListPage.vue
@@ -21,7 +21,7 @@ defineProps({
         <div class="space-y-6">
           <div
             v-for="(mentor, index) in mentors.data"
-            :key="index"
+            :key="mentor.userSlug"
             class="overflow-hidden rounded-lg bg-white shadow-sm"
           >
             <div class="flex items-start gap-6 p-6">

--- a/resources/js/Pages/Profile/MentorListPage.vue
+++ b/resources/js/Pages/Profile/MentorListPage.vue
@@ -1,0 +1,100 @@
+<script setup>
+import { Link } from '@inertiajs/vue3';
+
+import AppPagination from '@/Components/Navigation/AppPagination.vue';
+import LandingLayout from '@/Layouts/LandingLayout.vue';
+
+defineProps({
+  mentors: {
+    type: Object,
+    required: true,
+  },
+});
+</script>
+
+<template>
+  <LandingLayout>
+    <div class="bg-gray-100 py-16">
+      <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <h1 class="mb-8 text-3xl font-bold text-gray-900">Find a Mentor</h1>
+
+        <div class="space-y-6">
+          <div
+            v-for="(mentor, index) in mentors.data"
+            :key="index"
+            class="overflow-hidden rounded-lg bg-white shadow-sm"
+          >
+            <div class="flex items-start gap-6 p-6">
+              <Link :href="route('page.mentor', mentor.userSlug)">
+                <img
+                  :src="mentor.userAvatar"
+                  :alt="mentor.userName"
+                  class="h-20 w-20 flex-shrink-0 rounded-full object-cover"
+                />
+              </Link>
+
+              <div class="min-w-0 flex-1">
+                <div class="flex items-start justify-between">
+                  <div>
+                    <Link
+                      :href="route('page.mentor', mentor.userSlug)"
+                      class="text-lg font-semibold text-gray-900 hover:text-indigo-600"
+                    >
+                      {{ mentor.userName }}
+                    </Link>
+                    <p class="mt-0.5 text-sm text-gray-600">
+                      {{ mentor.title }}
+                    </p>
+                  </div>
+
+                  <div class="ml-4 flex-shrink-0 text-right">
+                    <p class="text-lg font-semibold text-indigo-600">
+                      {{ mentor.rate }}
+                      <span v-if="mentor.currency">{{
+                        mentor.currency.symbol
+                      }}</span>
+                      <span class="text-sm font-normal text-gray-500"
+                        >/hour</span
+                      >
+                    </p>
+                  </div>
+                </div>
+
+                <p class="mt-2 line-clamp-2 text-sm text-gray-500">
+                  {{ mentor.description }}
+                </p>
+
+                <div class="mt-4 flex items-center justify-end gap-3">
+                  <Link
+                    :href="route('page.mentor', mentor.userSlug)"
+                    class="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+                  >
+                    View Profile
+                  </Link>
+                  <a
+                    v-if="mentor.mainProgramSlug"
+                    :href="
+                      route('pages.mentor.program.book', mentor.mainProgramSlug)
+                    "
+                    class="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500"
+                  >
+                    Book Consultation
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div
+            v-if="mentors.data.length === 0"
+            class="py-12 text-center text-gray-500"
+          >
+            No mentors found.
+          </div>
+        </div>
+
+        <AppPagination :data="mentors" />
+      </div>
+    </div>
+  </LandingLayout>
+</template>

--- a/resources/js/Stores/navigation.js
+++ b/resources/js/Stores/navigation.js
@@ -11,6 +11,7 @@ export const useNavigation = defineStore('navigation', () => {
   const landingNavigation = ref([
     { name: 'Product', href: '#' },
     { name: 'Features', href: '#' },
+    { name: 'Mentors', href: route('page.profile-programs') },
     { name: 'Marketplace', href: '#' },
     { name: 'Company', href: '#' },
   ]);
@@ -18,6 +19,7 @@ export const useNavigation = defineStore('navigation', () => {
   const authenticatedNavigation = computed(() => {
     const base = [
       { name: 'Dashboard', href: route('pages.dashboard') },
+      { name: 'Mentors', href: route('page.profile-programs') },
       { name: 'Team', href: '#' },
       { name: 'Projects', href: '#' },
       { name: 'Calendar', href: route('pages.calendar.index') },

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,6 +10,7 @@ use App\Actions\MentorPrograms\DeleteMentorProgram;
 use App\Actions\MentorPrograms\StoreMentorProgramPage;
 use App\Actions\MentorPrograms\UpdateMentorProgramPage;
 use App\Actions\Pages\Calendar\CalendarsListPage;
+use App\Actions\Pages\Calendar\ConfirmedCalendarEventsListPage;
 use App\Actions\Pages\Calendar\MentorProgramEventBookingPage;
 use App\Actions\Pages\Calendar\PendingCalendarEventsListPage;
 use App\Actions\Pages\Calendar\ShowCalendarEventPage;
@@ -50,19 +51,19 @@ Route::middleware('auth')->group(function (): void {
     Route::delete('profile', DeleteUserProfile::class)->name('profile.destroy');
 });
 
-Route::middleware(['auth', 'role:mentor'])->group(function (): void {
-    Route::get('mentor-program/create', CreateMentorProgramPage::class)
+Route::prefix('mentor-program')->middleware(['auth', 'role:mentor'])->group(function (): void {
+    Route::get('/create', CreateMentorProgramPage::class)
         ->name('mentor-program.create');
-    Route::post('mentor-program', StoreMentorProgramPage::class)->name('mentor-program.store');
-    Route::get('mentor-program/{mentorProgram:slug}/edit', EditMentorProgramPage::class)
+    Route::post('/', StoreMentorProgramPage::class)->name('mentor-program.store');
+    Route::get('/{mentorProgram:slug}/edit', EditMentorProgramPage::class)
         ->name('mentor-program.edit');
-    Route::patch('mentor-program/{mentorProgram:slug}', UpdateMentorProgramPage::class)
+    Route::patch('/{mentorProgram:slug}', UpdateMentorProgramPage::class)
         ->can('update', 'mentorProgram')
         ->name('mentor-program.update');
-    Route::delete('mentor-program/{mentorProgram:slug}', DeleteMentorProgram::class)
+    Route::delete('/{mentorProgram:slug}', DeleteMentorProgram::class)
         ->can('delete', 'mentorProgram')
         ->name('mentor-program.destroy');
-    Route::get('mentor-program/list', ListMentorProgramPage::class)
+    Route::get('/list', ListMentorProgramPage::class)
         ->name('mentor-program.list');
 });
 
@@ -74,6 +75,8 @@ Route::prefix('calendar')->middleware(['auth', 'verified'])->group(function (): 
         ->name('pages.calendar.show');
     Route::get('pending-calendar-event/list/{mentorProgram:slug?}', PendingCalendarEventsListPage::class)
         ->name('pages.calendar.pending');
+    Route::get('confirmed-calendar-event/list/{mentorProgram:slug?}', ConfirmedCalendarEventsListPage::class)
+        ->name('pages.calendar.confirmed');
     Route::get('mentor-program/book/{mentorProgram:slug}', MentorProgramEventBookingPage::class)
         ->name('pages.mentor.program.book');
     Route::post('calendar-event/store', StoreCalendarEvent::class)
@@ -81,7 +84,8 @@ Route::prefix('calendar')->middleware(['auth', 'verified'])->group(function (): 
     Route::patch('calendar-event/edit/{calendarEvent:id}', EditCalendarEvent::class)
         ->can('update', 'calendarEvent')
         ->name('pages.calendar.edit');
-    Route::patch('mentor-programs/{mentorProgram:id}/calendar-events/{calendarEvent:id}/confirm', ConfirmCalendarEvent::class)
+    Route::patch('mentor-programs/{mentorProgram:id}/calendar-events/{calendarEvent:id}/confirm',
+        ConfirmCalendarEvent::class)
         ->can('update', 'calendarEvent')
         ->name('calendar.confirm.booking');
     Route::delete('calendar-event/delete/{calendarEvent}', DeleteCalendarEvent::class)

--- a/tests/Feature/MentorPrograms/StoreMentorProgramTest.php
+++ b/tests/Feature/MentorPrograms/StoreMentorProgramTest.php
@@ -36,7 +36,7 @@ describe('Mentor Program Store Page', function (): void {
         $response = $this->withSession(['_token' => 'test_token'])
             ->post(route('mentor-program.store'), $programData);
 
-        $response->assertRedirect(route('mentor-program.create'));
+        $response->assertRedirect(route('mentor-program.list'));
 
         $this->assertDatabaseHas('mentor_programs', [
             'mentor_id'   => $this->user->getKey(),

--- a/tests/Feature/Pages/Calendar/ConfirmedCalendarEventsListPageTest.php
+++ b/tests/Feature/Pages/Calendar/ConfirmedCalendarEventsListPageTest.php
@@ -62,12 +62,13 @@ describe('ConfirmedCalendarEventsListPage (Feature)', function (): void {
         $response = $this->get(route('pages.calendar.confirmed'));
 
         $response->assertStatus(Response::HTTP_OK);
+
         $response->assertInertia(fn (Assert $page): AssertableJson => $page
             ->component('Calendar/ListConfirmedCalendarEventsPage')
             ->has('locale')
             ->has('calendarEvents', fn (AssertableJson $events): AssertableJson => $events
-                ->whereType('Program A', 'array')
-                ->whereType('Program B', 'array')
+                ->whereType((string) $this->programA->getKey(), 'array')
+                ->whereType((string) $this->programB->getKey(), 'array')
                 ->etc()
             )
         );
@@ -146,7 +147,7 @@ describe('ConfirmedCalendarEventsListPage (Feature)', function (): void {
         $response->assertInertia(fn (Assert $page): AssertableJson => $page
             ->component('Calendar/ListConfirmedCalendarEventsPage')
             ->has('calendarEvents', fn (AssertableJson $events): AssertableJson => $events
-                ->has('Program A')
+                ->has((string) $this->programA->getKey())
             )
         );
     });

--- a/tests/Feature/Pages/Calendar/ConfirmedCalendarEventsListPageTest.php
+++ b/tests/Feature/Pages/Calendar/ConfirmedCalendarEventsListPageTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\CalendarEventStatusEnum;
+use App\Enums\CalendarEventTypeEnum;
+use App\Enums\RoleEnum;
+use App\Models\CalendarEvent;
+use App\Models\MentorProgram;
+use App\Models\User;
+use Database\Seeders\RoleSeeder;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Testing\Fluent\AssertableJson;
+use Inertia\Testing\AssertableInertia as Assert;
+use Spatie\Permission\Models\Role;
+use Symfony\Component\HttpFoundation\Response;
+
+describe('ConfirmedCalendarEventsListPage (Feature)', function (): void {
+    beforeEach(function (): void {
+        $this->seed(RoleSeeder::class);
+        $this->mentor = User::factory()->create();
+        $this->mentor->assignRole(Role::findByName(RoleEnum::MENTOR->value));
+
+        $this->programA = MentorProgram::factory()->create([
+            'mentor_id' => $this->mentor->getKey(),
+            'name'      => 'Program A',
+        ]);
+        $this->programB = MentorProgram::factory()->create([
+            'mentor_id' => $this->mentor->getKey(),
+            'name'      => 'Program B',
+        ]);
+    });
+
+    it('redirects guest to login', function (): void {
+        $this->get(route('pages.calendar.confirmed'))
+            ->assertRedirect(route('login'));
+    });
+
+    it('renders confirmed upcoming events grouped by mentor program name', function (): void {
+        $this->actingAs($this->mentor);
+
+        $eventA = CalendarEvent::factory()->create([
+            'status'            => CalendarEventStatusEnum::CONFIRMED,
+            'type'              => CalendarEventTypeEnum::INDIVIDUAL,
+            'mentor_program_id' => $this->programA->getKey(),
+            'date'              => Date::tomorrow()->toDateString(),
+            'start_date_time'   => Date::now()->addDay(),
+            'end_date_time'     => Date::now()->addDay()->addHour(),
+        ]);
+        $eventA->calendarEventUsers()->attach($this->mentor->getKey());
+
+        $eventB = CalendarEvent::factory()->create([
+            'status'            => CalendarEventStatusEnum::CONFIRMED,
+            'type'              => CalendarEventTypeEnum::INDIVIDUAL,
+            'mentor_program_id' => $this->programB->getKey(),
+            'date'              => Date::tomorrow()->toDateString(),
+            'start_date_time'   => Date::now()->addDays(2),
+            'end_date_time'     => Date::now()->addDays(2)->addHour(),
+        ]);
+        $eventB->calendarEventUsers()->attach($this->mentor->getKey());
+
+        $response = $this->get(route('pages.calendar.confirmed'));
+
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertInertia(fn (Assert $page): AssertableJson => $page
+            ->component('Calendar/ListConfirmedCalendarEventsPage')
+            ->has('locale')
+            ->has('calendarEvents', fn (AssertableJson $events): AssertableJson => $events
+                ->whereType('Program A', 'array')
+                ->whereType('Program B', 'array')
+                ->etc()
+            )
+        );
+    });
+
+    it('excludes past confirmed events', function (): void {
+        $this->actingAs($this->mentor);
+
+        $pastEvent = CalendarEvent::factory()->create([
+            'status'            => CalendarEventStatusEnum::CONFIRMED,
+            'type'              => CalendarEventTypeEnum::INDIVIDUAL,
+            'mentor_program_id' => $this->programA->getKey(),
+            'date'              => Date::yesterday()->toDateString(),
+            'start_date_time'   => Date::now()->subDay(),
+            'end_date_time'     => Date::now()->subDay()->addHour(),
+        ]);
+        $pastEvent->calendarEventUsers()->attach($this->mentor->getKey());
+
+        $response = $this->get(route('pages.calendar.confirmed'));
+
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertInertia(fn (Assert $page): AssertableJson => $page
+            ->component('Calendar/ListConfirmedCalendarEventsPage')
+            ->where('calendarEvents', [])
+        );
+    });
+
+    it('excludes pending events', function (): void {
+        $this->actingAs($this->mentor);
+
+        $pendingEvent = CalendarEvent::factory()->create([
+            'status'            => CalendarEventStatusEnum::PENDING_MENTOR_CONFIRMATION,
+            'type'              => CalendarEventTypeEnum::INDIVIDUAL,
+            'mentor_program_id' => $this->programA->getKey(),
+            'date'              => Date::tomorrow()->toDateString(),
+            'start_date_time'   => Date::now()->addDay(),
+            'end_date_time'     => Date::now()->addDay()->addHour(),
+        ]);
+        $pendingEvent->calendarEventUsers()->attach($this->mentor->getKey());
+
+        $response = $this->get(route('pages.calendar.confirmed'));
+
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertInertia(fn (Assert $page): AssertableJson => $page
+            ->component('Calendar/ListConfirmedCalendarEventsPage')
+            ->where('calendarEvents', [])
+        );
+    });
+
+    it('filters by mentor program slug when provided', function (): void {
+        $this->actingAs($this->mentor);
+
+        $eventA = CalendarEvent::factory()->create([
+            'status'            => CalendarEventStatusEnum::CONFIRMED,
+            'type'              => CalendarEventTypeEnum::INDIVIDUAL,
+            'mentor_program_id' => $this->programA->getKey(),
+            'date'              => Date::tomorrow()->toDateString(),
+            'start_date_time'   => Date::now()->addDay(),
+            'end_date_time'     => Date::now()->addDay()->addHour(),
+        ]);
+        $eventA->calendarEventUsers()->attach($this->mentor->getKey());
+
+        $eventB = CalendarEvent::factory()->create([
+            'status'            => CalendarEventStatusEnum::CONFIRMED,
+            'type'              => CalendarEventTypeEnum::INDIVIDUAL,
+            'mentor_program_id' => $this->programB->getKey(),
+            'date'              => Date::tomorrow()->toDateString(),
+            'start_date_time'   => Date::now()->addDays(2),
+            'end_date_time'     => Date::now()->addDays(2)->addHour(),
+        ]);
+        $eventB->calendarEventUsers()->attach($this->mentor->getKey());
+
+        $response = $this->get(route('pages.calendar.confirmed', $this->programA->slug));
+
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertInertia(fn (Assert $page): AssertableJson => $page
+            ->component('Calendar/ListConfirmedCalendarEventsPage')
+            ->has('calendarEvents', fn (AssertableJson $events): AssertableJson => $events
+                ->has('Program A')
+            )
+        );
+    });
+
+    it('returns empty calendarEvents when no confirmed future events exist', function (): void {
+        $this->actingAs($this->mentor);
+
+        $response = $this->get(route('pages.calendar.confirmed'));
+
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertInertia(fn (Assert $page): AssertableJson => $page
+            ->component('Calendar/ListConfirmedCalendarEventsPage')
+            ->has('locale')
+            ->where('calendarEvents', [])
+        );
+    });
+});

--- a/tests/Feature/Pages/MentorProfile/ListMentorProfilePageTest.php
+++ b/tests/Feature/Pages/MentorProfile/ListMentorProfilePageTest.php
@@ -410,10 +410,12 @@ describe('ListMentorProfilePage filters and includes', function (): void {
         ]);
 
         // Create a non-main program
-        MentorProgram::factory()->create([
+        $mentorProgram = MentorProgram::factory()->create([
             'mentor_id' => $user->getKey(),
-            'is_main'   => false,
         ]);
+
+        $mentorProgram->update(['is_main' => false]);
+        $mentorProgram->save();
 
         $response = $this->get(route('page.profile-programs'));
 

--- a/tests/Feature/Pages/MentorProfile/ListMentorProfilePageTest.php
+++ b/tests/Feature/Pages/MentorProfile/ListMentorProfilePageTest.php
@@ -11,6 +11,7 @@ use App\Models\MentorReview;
 use App\Models\MentorTag;
 use App\Models\User;
 use Database\Seeders\RoleSeeder;
+use Inertia\Testing\AssertableInertia as Assert;
 
 mutates(ListMentorProfilePage::class);
 
@@ -55,104 +56,149 @@ describe('ListMentorProfilePage filters and includes', function (): void {
     });
 
     it('lists all profiles by default (no filters)', function (): void {
-        $resp = $this->getJson(route('page.profile-programs'));
-        $resp->assertOk();
+        $response = $this->get(route('page.profile-programs'));
 
-        $data = $resp->json('data');
-        expect($data)->toBeArray()->and(count($data))->toBe(3);
+        $response->assertOk();
+        $response->assertInertia(fn (Assert $page): Assert => $page
+            ->component('Profile/MentorListPage')
+            ->has('mentors.data', 3)
+        );
     });
 
-    it('filters by title and description', function (): void {
-        $this->getJson(route('page.profile-programs', ['filter' => ['title' => 'Laravel']]))
-            ->assertOk()
-            ->assertJsonCount(1, 'data')
-            ->assertJsonFragment(['title' => 'Laravel Guru']);
+    it('filters by title', function (): void {
+        $response = $this->get(route('page.profile-programs', ['filter' => ['title' => 'Laravel']]));
 
-        $this->getJson(route('page.profile-programs', ['filter' => ['description' => 'Frontend']]))
-            ->assertOk()
-            ->assertJsonCount(1, 'data')
-            ->assertJsonFragment(['title' => 'React Ninja']);
+        $response->assertOk();
+        $response->assertInertia(fn (Assert $page): Assert => $page
+            ->component('Profile/MentorListPage')
+            ->has('mentors.data', 1)
+            ->where('mentors.data.0.title', 'Laravel Guru')
+        );
     });
 
-    it('filters by mentor program fields', function (): void {
-        $this->getJson(route('page.profile-programs', ['filter' => ['mentorPrograms.name' => 'Advanced'], 'include' => 'mentorPrograms']))
-            ->assertOk()
-            ->assertJsonCount(1, 'data')
-            ->assertJsonFragment(['name' => 'Advanced PHP']);
-        $this->getJson(route('page.profile-programs', ['filter' => ['mentorPrograms.description' => 'Python'], 'include' => 'mentorPrograms']))
-            ->assertOk()
-            ->assertJsonCount(1, 'data')
-            ->assertJsonFragment(['name' => 'Python Junior']);
+    it('filters by description', function (): void {
+        $response = $this->get(route('page.profile-programs', ['filter' => ['description' => 'Frontend']]));
+
+        $response->assertOk();
+        $response->assertInertia(fn (Assert $page): Assert => $page
+            ->component('Profile/MentorListPage')
+            ->has('mentors.data', 1)
+            ->where('mentors.data.0.title', 'React Ninja')
+        );
+    });
+
+    it('filters by mentor program name', function (): void {
+        $response = $this->get(route('page.profile-programs', ['filter' => ['mentorPrograms.name' => 'Advanced']]));
+
+        $response->assertOk();
+        $response->assertInertia(fn (Assert $page): Assert => $page
+            ->component('Profile/MentorListPage')
+            ->has('mentors.data', 1)
+            ->where('mentors.data.0.title', 'Laravel Guru')
+        );
+    });
+
+    it('filters by mentor program description', function (): void {
+        $response = $this->get(route('page.profile-programs', ['filter' => ['mentorPrograms.description' => 'Python']]));
+
+        $response->assertOk();
+        $response->assertInertia(fn (Assert $page): Assert => $page
+            ->component('Profile/MentorListPage')
+            ->has('mentors.data', 1)
+            ->where('mentors.data.0.title', 'Python Master')
+        );
     });
 
     it('filters by rate range using array params', function (): void {
-        $this->getJson(route('page.profile-programs', ['filter' => ['rate' => ['min' => 50, 'max' => 90]]]))
-            ->assertOk()
-            ->assertJsonCount(2, 'data')
-            ->assertJsonFragment(['title' => 'Laravel Guru'])
-            ->assertJsonFragment(['title' => 'React Ninja']);
-        $this->getJson(route('page.profile-programs', ['filter' => ['rate' => ['min' => 0, 'max' => 50]]]))
-            ->assertOk()
-            ->assertJsonCount(1, 'data')
-            ->assertJsonFragment(['title' => 'Python Master']);
+        $response = $this->get(route('page.profile-programs', ['filter' => ['rate' => ['min' => 50, 'max' => 90]]]));
 
+        $response->assertOk();
+        $response->assertInertia(fn (Assert $page): Assert => $page
+            ->component('Profile/MentorListPage')
+            ->has('mentors.data', 2)
+        );
+
+        $response2 = $this->get(route('page.profile-programs', ['filter' => ['rate' => ['min' => 0, 'max' => 50]]]));
+
+        $response2->assertOk();
+        $response2->assertInertia(fn (Assert $page): Assert => $page
+            ->component('Profile/MentorListPage')
+            ->has('mentors.data', 1)
+            ->where('mentors.data.0.title', 'Python Master')
+        );
     });
 
     it('filters by cost range via related mentorPrograms using array params', function (): void {
-        $this->getJson(route('page.profile-programs', ['filter' => ['cost' => ['min' => 0, 'max' => 300]]]))
-            ->assertOk()
-            ->assertJsonCount(2, 'data');
+        $response = $this->get(route('page.profile-programs', ['filter' => ['cost' => ['min' => 0, 'max' => 300]]]));
 
-        $this->getJson(route('page.profile-programs', ['filter' => ['cost' => ['min' => 500, 'max' => 700]]]))
-            ->assertOk()
-            ->assertJsonCount(1, 'data')
-            ->assertJsonFragment(['title' => 'Laravel Guru']);
+        $response->assertOk();
+        $response->assertInertia(fn (Assert $page): Assert => $page
+            ->component('Profile/MentorListPage')
+            ->has('mentors.data', 2)
+        );
 
-        $this->getJson(route('page.profile-programs', ['filter' => ['cost' => ['min' => 0, 'max' => 300]]]))
-            ->assertOk()
-            ->assertJsonCount(2, 'data');
+        $response2 = $this->get(route('page.profile-programs', ['filter' => ['cost' => ['min' => 500, 'max' => 700]]]));
+
+        $response2->assertOk();
+        $response2->assertInertia(fn (Assert $page): Assert => $page
+            ->component('Profile/MentorListPage')
+            ->has('mentors.data', 1)
+            ->where('mentors.data.0.title', 'Laravel Guru')
+        );
     });
 
     it('filters by languages and stacks', function (): void {
-        $this->getJson(route('page.profile-programs', ['filter' => ['languages' => 'PHP']]))
-            ->assertOk()
-            ->assertJsonCount(2, 'data');
+        $response = $this->get(route('page.profile-programs', ['filter' => ['languages' => 'PHP']]));
 
-        $this->getJson(route('page.profile-programs', ['filter' => ['stacks' => 'Laravel']]))
-            ->assertOk()
-            ->assertJsonCount(2, 'data');
-    });
+        $response->assertOk();
+        $response->assertInertia(fn (Assert $page): Assert => $page
+            ->component('Profile/MentorListPage')
+            ->has('mentors.data', 2)
+        );
 
-    it('supports includes for mentorPrograms and mentorTags', function (): void {
-        $resp = $this->getJson(route('page.profile-programs', ['include' => 'mentorPrograms,mentorTags']));
-        $resp->assertOk();
+        $response2 = $this->get(route('page.profile-programs', ['filter' => ['stacks' => 'Laravel']]));
 
-        $first = $resp->json('data.0');
-        expect($first)->toHaveKeys(['mentor_programs', 'mentor_tags']);
+        $response2->assertOk();
+        $response2->assertInertia(fn (Assert $page): Assert => $page
+            ->component('Profile/MentorListPage')
+            ->has('mentors.data', 2)
+        );
     });
 
     it('supports sorting by rate desc', function (): void {
-        $resp = $this->getJson(route('page.profile-programs', ['sort' => '-rate']));
-        $resp->assertOk();
+        $response = $this->get(route('page.profile-programs', ['sort' => '-rate']));
 
-        $titles = array_column($resp->json('data'), 'title');
-        expect($titles)->toBe(['Laravel Guru', 'React Ninja', 'Python Master']);
+        $response->assertOk();
+        $response->assertInertia(fn (Assert $page): Assert => $page
+            ->component('Profile/MentorListPage')
+            ->where('mentors.data.0.title', 'Laravel Guru')
+            ->where('mentors.data.1.title', 'React Ninja')
+            ->where('mentors.data.2.title', 'Python Master')
+        );
     });
 
     it('supports sorting by id desc', function (): void {
-        $resp = $this->getJson(route('page.profile-programs', ['sort' => '-id']));
-        $resp->assertOk();
+        $response = $this->get(route('page.profile-programs', ['sort' => '-id']));
 
-        $titles = array_column($resp->json('data'), 'title');
-        expect($titles)->toBe(['Python Master', 'React Ninja', 'Laravel Guru']);
+        $response->assertOk();
+        $response->assertInertia(fn (Assert $page): Assert => $page
+            ->component('Profile/MentorListPage')
+            ->where('mentors.data.0.title', 'Python Master')
+            ->where('mentors.data.1.title', 'React Ninja')
+            ->where('mentors.data.2.title', 'Laravel Guru')
+        );
     });
 
     it('supports sorting by experience_started_at asc', function (): void {
-        $resp = $this->getJson(route('page.profile-programs', ['sort' => 'experience_started_at']));
-        $resp->assertOk();
+        $response = $this->get(route('page.profile-programs', ['sort' => 'experience_started_at']));
 
-        $titles = array_column($resp->json('data'), 'title');
-        expect($titles)->toBe(['Python Master', 'Laravel Guru', 'React Ninja']);
+        $response->assertOk();
+        $response->assertInertia(fn (Assert $page): Assert => $page
+            ->component('Profile/MentorListPage')
+            ->where('mentors.data.0.title', 'Python Master')
+            ->where('mentors.data.1.title', 'Laravel Guru')
+            ->where('mentors.data.2.title', 'React Ninja')
+        );
     });
 
     it('filters by single experience level', function (): void {
@@ -175,25 +221,33 @@ describe('ListMentorProfilePage filters and includes', function (): void {
             'experience_started_at' => now()->subYears(15),
         ]);
 
-        $this->getJson(route('page.profile-programs', ['filter' => ['experience' => 'entry']]))
+        $this->get(route('page.profile-programs', ['filter' => ['experience' => 'entry']]))
             ->assertOk()
-            ->assertJsonCount(1, 'data')
-            ->assertJsonFragment(['title' => 'Entry Level Dev']);
+            ->assertInertia(fn (Assert $page): Assert => $page
+                ->has('mentors.data', 1)
+                ->where('mentors.data.0.title', 'Entry Level Dev')
+            );
 
-        $this->getJson(route('page.profile-programs', ['filter' => ['experience' => 'mid']]))
+        $this->get(route('page.profile-programs', ['filter' => ['experience' => 'mid']]))
             ->assertOk()
-            ->assertJsonCount(1, 'data')
-            ->assertJsonFragment(['title' => 'Mid Level Dev']);
+            ->assertInertia(fn (Assert $page): Assert => $page
+                ->has('mentors.data', 1)
+                ->where('mentors.data.0.title', 'Mid Level Dev')
+            );
 
-        $this->getJson(route('page.profile-programs', ['filter' => ['experience' => 'senior']]))
+        $this->get(route('page.profile-programs', ['filter' => ['experience' => 'senior']]))
             ->assertOk()
-            ->assertJsonCount(1, 'data')
-            ->assertJsonFragment(['title' => 'Senior Dev']);
+            ->assertInertia(fn (Assert $page): Assert => $page
+                ->has('mentors.data', 1)
+                ->where('mentors.data.0.title', 'Senior Dev')
+            );
 
-        $this->getJson(route('page.profile-programs', ['filter' => ['experience' => 'expert']]))
+        $this->get(route('page.profile-programs', ['filter' => ['experience' => 'expert']]))
             ->assertOk()
-            ->assertJsonCount(1, 'data')
-            ->assertJsonFragment(['title' => 'Expert Dev']);
+            ->assertInertia(fn (Assert $page): Assert => $page
+                ->has('mentors.data', 1)
+                ->where('mentors.data.0.title', 'Expert Dev')
+            );
     });
 
     it('filters by multiple experience levels', function (): void {
@@ -216,17 +270,17 @@ describe('ListMentorProfilePage filters and includes', function (): void {
             'experience_started_at' => now()->subYears(15),
         ]);
 
-        $this->getJson(route('page.profile-programs', ['filter' => ['experience' => 'mid,senior']]))
+        $this->get(route('page.profile-programs', ['filter' => ['experience' => 'mid,senior']]))
             ->assertOk()
-            ->assertJsonCount(2, 'data')
-            ->assertJsonFragment(['title' => 'Mid Level Dev'])
-            ->assertJsonFragment(['title' => 'Senior Dev']);
+            ->assertInertia(fn (Assert $page): Assert => $page
+                ->has('mentors.data', 2)
+            );
 
-        $this->getJson(route('page.profile-programs', ['filter' => ['experience' => 'entry,expert']]))
+        $this->get(route('page.profile-programs', ['filter' => ['experience' => 'entry,expert']]))
             ->assertOk()
-            ->assertJsonCount(2, 'data')
-            ->assertJsonFragment(['title' => 'Entry Level Dev'])
-            ->assertJsonFragment(['title' => 'Expert Dev']);
+            ->assertInertia(fn (Assert $page): Assert => $page
+                ->has('mentors.data', 2)
+            );
     });
 
     it('filters by minimum rating', function (): void {
@@ -235,7 +289,7 @@ describe('ListMentorProfilePage filters and includes', function (): void {
         $mentor1 = MentorProfile::factory()->create(['title' => 'Low Rated Mentor']);
         $mentor2 = MentorProfile::factory()->create(['title' => 'Good Rated Mentor']);
         $mentor3 = MentorProfile::factory()->create(['title' => 'Excellent Rated Mentor']);
-        $mentor4 = MentorProfile::factory()->create(['title' => 'No Rating Mentor']);
+        MentorProfile::factory()->create(['title' => 'No Rating Mentor']);
 
         MentorReview::factory()->create(['mentor_id' => $mentor1->user_id, 'rating' => 2]);
         MentorReview::factory()->create(['mentor_id' => $mentor1->user_id, 'rating' => 3]);
@@ -247,22 +301,24 @@ describe('ListMentorProfilePage filters and includes', function (): void {
         MentorReview::factory()->create(['mentor_id' => $mentor3->user_id, 'rating' => 5]);
         MentorReview::factory()->create(['mentor_id' => $mentor3->user_id, 'rating' => 4]);
 
-        $this->getJson(route('page.profile-programs', ['filter' => ['rating' => 4]]))
+        $this->get(route('page.profile-programs', ['filter' => ['rating' => 4]]))
             ->assertOk()
-            ->assertJsonCount(2, 'data')
-            ->assertJsonFragment(['title' => 'Good Rated Mentor'])
-            ->assertJsonFragment(['title' => 'Excellent Rated Mentor']);
+            ->assertInertia(fn (Assert $page): Assert => $page
+                ->has('mentors.data', 2)
+            );
 
-        $this->getJson(route('page.profile-programs', ['filter' => ['rating' => 4.5]]))
+        $this->get(route('page.profile-programs', ['filter' => ['rating' => 4.5]]))
             ->assertOk()
-            ->assertJsonCount(1, 'data')
-            ->assertJsonFragment(['title' => 'Excellent Rated Mentor']);
+            ->assertInertia(fn (Assert $page): Assert => $page
+                ->has('mentors.data', 1)
+                ->where('mentors.data.0.title', 'Excellent Rated Mentor')
+            );
 
-        $this->getJson(route('page.profile-programs', ['filter' => ['rating' => 3]]))
+        $this->get(route('page.profile-programs', ['filter' => ['rating' => 3]]))
             ->assertOk()
-            ->assertJsonCount(2, 'data')
-            ->assertJsonFragment(['title' => 'Good Rated Mentor'])
-            ->assertJsonFragment(['title' => 'Excellent Rated Mentor']);
+            ->assertInertia(fn (Assert $page): Assert => $page
+                ->has('mentors.data', 2)
+            );
     });
 
     it('combines experience and rating filters', function (): void {
@@ -290,15 +346,82 @@ describe('ListMentorProfilePage filters and includes', function (): void {
         MentorReview::factory()->create(['mentor_id' => $mentor3->user_id, 'rating' => 5]);
         MentorReview::factory()->create(['mentor_id' => $mentor3->user_id, 'rating' => 4]);
 
-        $this->getJson(route('page.profile-programs', ['filter' => ['experience' => 'senior', 'rating' => 4]]))
+        $this->get(route('page.profile-programs', ['filter' => ['experience' => 'senior', 'rating' => 4]]))
             ->assertOk()
-            ->assertJsonCount(1, 'data')
-            ->assertJsonFragment(['title' => 'Senior High Rated']);
+            ->assertInertia(fn (Assert $page): Assert => $page
+                ->has('mentors.data', 1)
+                ->where('mentors.data.0.title', 'Senior High Rated')
+            );
 
-        $this->getJson(route('page.profile-programs', ['filter' => ['experience' => 'mid,senior', 'rating' => 4.5]]))
+        $this->get(route('page.profile-programs', ['filter' => ['experience' => 'mid,senior', 'rating' => 4.5]]))
             ->assertOk()
-            ->assertJsonCount(2, 'data')
-            ->assertJsonFragment(['title' => 'Senior High Rated'])
-            ->assertJsonFragment(['title' => 'Mid High Rated']);
+            ->assertInertia(fn (Assert $page): Assert => $page
+                ->has('mentors.data', 2)
+            );
+    });
+
+    it('returns correct data shape for each mentor item', function (): void {
+        $response = $this->get(route('page.profile-programs'));
+
+        $response->assertOk();
+        $response->assertInertia(fn (Assert $page): Assert => $page
+            ->component('Profile/MentorListPage')
+            ->has('mentors.data.0', fn (Assert $item): Assert => $item
+                ->hasAll(['title', 'description', 'rate', 'currency', 'userSlug', 'userName', 'userAvatar', 'mainProgramSlug'])
+            )
+        );
+    });
+
+    it('returns mainProgramSlug when mentor has a main program', function (): void {
+        MentorProfile::query()->delete();
+
+        $user = User::factory()->create();
+        $user->assignRole(RoleEnum::MENTOR->value);
+
+        $profile = MentorProfile::factory()->create([
+            'title'   => 'Mentor With Main Program',
+            'user_id' => $user->getKey(),
+        ]);
+
+        $mainProgram = MentorProgram::factory()->main()->create([
+            'mentor_id' => $user->getKey(),
+            'slug'      => 'main-program-slug',
+        ]);
+
+        $response = $this->get(route('page.profile-programs'));
+
+        $response->assertOk();
+        $response->assertInertia(fn (Assert $page): Assert => $page
+            ->component('Profile/MentorListPage')
+            ->has('mentors.data', 1)
+            ->where('mentors.data.0.mainProgramSlug', 'main-program-slug')
+        );
+    });
+
+    it('returns null mainProgramSlug when mentor has no main program', function (): void {
+        MentorProfile::query()->delete();
+
+        $user = User::factory()->create();
+        $user->assignRole(RoleEnum::MENTOR->value);
+
+        MentorProfile::factory()->create([
+            'title'   => 'Mentor Without Main Program',
+            'user_id' => $user->getKey(),
+        ]);
+
+        // Create a non-main program
+        MentorProgram::factory()->create([
+            'mentor_id' => $user->getKey(),
+            'is_main'   => false,
+        ]);
+
+        $response = $this->get(route('page.profile-programs'));
+
+        $response->assertOk();
+        $response->assertInertia(fn (Assert $page): Assert => $page
+            ->component('Profile/MentorListPage')
+            ->has('mentors.data', 1)
+            ->where('mentors.data.0.mainProgramSlug', null)
+        );
     });
 });

--- a/tests/Unit/Actions/MentorProfile/ListMentorProfilePageTest.php
+++ b/tests/Unit/Actions/MentorProfile/ListMentorProfilePageTest.php
@@ -9,6 +9,7 @@ use App\Filters\ProgramCostFilter;
 use App\Filters\RatingFilter;
 use App\Filters\TagLanguagesFilter;
 use App\Filters\TagStacksFilter;
+use Inertia\Response;
 use Lorisleiva\Actions\Concerns\AsController;
 
 mutates(ListMentorProfilePage::class);
@@ -23,6 +24,14 @@ describe('ListMentorProfilePage unit tests', function (): void {
         $reflection = new ReflectionMethod($action, 'handle');
         expect($reflection->isPublic())->toBeTrue()
             ->and($reflection->getNumberOfParameters())->toBe(0);
+    });
+
+    it('handle method returns Inertia Response', function (): void {
+        $reflection = new ReflectionMethod(ListMentorProfilePage::class, 'handle');
+        $returnType = $reflection->getReturnType();
+
+        expect($returnType)->not->toBeNull()
+            ->and($returnType->getName())->toBe(Response::class);
     });
 
     it('uses AsController trait', function (): void {

--- a/tests/Unit/Actions/MentorPrograms/StoreMentorProgramTest.php
+++ b/tests/Unit/Actions/MentorPrograms/StoreMentorProgramTest.php
@@ -161,7 +161,7 @@ describe('Store Mentor Program', function (): void {
         $response = (new StoreMentorProgramPage)->handle($request);
 
         expect($response)->toBeInstanceOf(Response::class)
-            ->and($response->getTargetUrl())->toBe(route('mentor-program.create'));
+            ->and($response->getTargetUrl())->toBe(route('mentor-program.list'));
     });
 
 });

--- a/tests/Unit/Actions/Pages/Calendar/ConfirmedCalendarEventsListPageTest.php
+++ b/tests/Unit/Actions/Pages/Calendar/ConfirmedCalendarEventsListPageTest.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Pages\Calendar\ConfirmedCalendarEventsListPage;
+use App\Enums\CalendarEventStatusEnum;
+use App\Enums\CalendarEventTypeEnum;
+use App\Enums\RoleEnum;
+use App\Models\CalendarEvent;
+use App\Models\MentorProgram;
+use App\Models\User;
+use Database\Seeders\RoleSeeder;
+use Illuminate\Support\Facades\Date;
+use Inertia\Response;
+use Spatie\Permission\Models\Role;
+
+mutates(ConfirmedCalendarEventsListPage::class);
+
+describe('ConfirmedCalendarEventsListPage (Unit)', function (): void {
+    beforeEach(function (): void {
+        $this->seed(RoleSeeder::class);
+        $this->mentor = User::factory()->create();
+        $this->mentor->assignRole(Role::findByName(RoleEnum::MENTOR->value));
+
+        $this->program = MentorProgram::factory()->create([
+            'mentor_id' => $this->mentor->getKey(),
+            'name'      => 'Program X',
+        ]);
+
+        $this->mentorProgram1 = MentorProgram::factory()->create([
+            'mentor_id' => $this->mentor->getKey(),
+            'name'      => 'Program A',
+        ]);
+
+        $this->mentorProgram2 = MentorProgram::factory()->create([
+            'mentor_id' => $this->mentor->getKey(),
+            'name'      => 'Program B',
+        ]);
+
+        $this->event = CalendarEvent::factory()->create([
+            'status'            => CalendarEventStatusEnum::CONFIRMED,
+            'type'              => CalendarEventTypeEnum::INDIVIDUAL,
+            'mentor_program_id' => $this->program->getKey(),
+            'date'              => Date::tomorrow()->toDateString(),
+            'start_date_time'   => Date::now()->addDay(),
+            'end_date_time'     => Date::now()->addDay()->addHour(),
+        ]);
+        $this->event->calendarEventUsers()->attach($this->mentor->getKey());
+
+        auth()->login($this->mentor);
+    });
+
+    it('returns inertia response with correct component and props', function (): void {
+        $response = new ConfirmedCalendarEventsListPage()->handle();
+        expect($response)->toBeInstanceOf(Response::class);
+
+        $page = $response->toResponse(request())->getOriginalContent()->getData()['page'];
+        expect($page['component'])->toBe('Calendar/ListConfirmedCalendarEventsPage')
+            ->and($page['props'])->toHaveKeys(['locale', 'calendarEvents'])
+            ->and($page['props']['calendarEvents'])->toHaveKey('Program X');
+    });
+
+    it('only includes confirmed events in the future', function (): void {
+        // Create a confirmed past event
+        $pastEvent = CalendarEvent::factory()->create([
+            'mentor_program_id' => $this->mentorProgram1->getKey(),
+            'status'            => CalendarEventStatusEnum::CONFIRMED->value,
+            'start_date_time'   => Date::now()->subDay(),
+            'end_date_time'     => Date::now()->subDay()->addHour(),
+        ]);
+        $pastEvent->calendarEventUsers()->attach($this->mentor->getKey());
+
+        // Create a pending future event
+        $pendingEvent = CalendarEvent::factory()->create([
+            'mentor_program_id' => $this->mentorProgram1->getKey(),
+            'status'            => CalendarEventStatusEnum::PENDING_MENTOR_CONFIRMATION->value,
+            'start_date_time'   => Date::now()->addDays(3),
+            'end_date_time'     => Date::now()->addDays(3)->addHour(),
+        ]);
+        $pendingEvent->calendarEventUsers()->attach($this->mentor->getKey());
+
+        // Create a confirmed future event
+        $futureEvent = CalendarEvent::factory()->create([
+            'mentor_program_id' => $this->mentorProgram1->getKey(),
+            'status'            => CalendarEventStatusEnum::CONFIRMED->value,
+            'start_date_time'   => Date::now()->addDays(2),
+            'end_date_time'     => Date::now()->addDays(2)->addHour(),
+        ]);
+        $futureEvent->calendarEventUsers()->attach($this->mentor->getKey());
+
+        $action = new ConfirmedCalendarEventsListPage;
+        $response = $action->handle();
+
+        expect($response)->toBeInstanceOf(Response::class);
+
+        $page = $response->toResponse(request())->getOriginalContent()->getData()['page'];
+        $props = $page['props'];
+
+        // Should have Program X (from beforeEach) and Program A (future confirmed)
+        $allEvents = collect($props['calendarEvents'])->flatten(1);
+
+        // The past and pending events should be excluded
+        $eventIds = $allEvents->pluck('id')->toArray();
+        expect($eventIds)->not->toContain($pastEvent->getKey())
+            ->and($eventIds)->not->toContain($pendingEvent->getKey())
+            ->and($eventIds)->toContain($futureEvent->getKey())
+            ->and($eventIds)->toContain($this->event->getKey());
+    });
+
+    it('groups events by mentor program name', function (): void {
+        $event1 = CalendarEvent::factory()->create([
+            'mentor_program_id' => $this->mentorProgram1->getKey(),
+            'status'            => CalendarEventStatusEnum::CONFIRMED->value,
+            'start_date_time'   => Date::now()->addDay(),
+            'end_date_time'     => Date::now()->addDay()->addHour(),
+        ]);
+
+        $event2 = CalendarEvent::factory()->create([
+            'mentor_program_id' => $this->mentorProgram1->getKey(),
+            'status'            => CalendarEventStatusEnum::CONFIRMED->value,
+            'start_date_time'   => Date::now()->addDays(2),
+            'end_date_time'     => Date::now()->addDays(2)->addHour(),
+        ]);
+
+        $this->mentor->calendarEvents()->attach([$event1->getKey(), $event2->getKey()]);
+
+        $action = new ConfirmedCalendarEventsListPage;
+        $response = $action->handle();
+
+        expect($response)->toBeInstanceOf(Response::class);
+
+        $page = $response->toResponse(request())->getOriginalContent()->getData()['page'];
+        $props = $page['props'];
+
+        expect($props['calendarEvents'])->toHaveKey('Program A')
+            ->and($props['calendarEvents']['Program A'])->toHaveCount(2);
+
+        foreach ($props['calendarEvents']['Program A'] as $event) {
+            expect($event['mentor_program_id'])->toBe($this->mentorProgram1->getKey());
+        }
+    });
+
+    it('filters by mentor program when provided', function (): void {
+        $event1 = CalendarEvent::factory()->create([
+            'mentor_program_id' => $this->mentorProgram1->getKey(),
+            'status'            => CalendarEventStatusEnum::CONFIRMED->value,
+            'start_date_time'   => Date::now()->addDay(),
+            'end_date_time'     => Date::now()->addDay()->addHour(),
+        ]);
+
+        $event2 = CalendarEvent::factory()->create([
+            'mentor_program_id' => $this->mentorProgram2->getKey(),
+            'status'            => CalendarEventStatusEnum::CONFIRMED->value,
+            'start_date_time'   => Date::now()->addDays(2),
+            'end_date_time'     => Date::now()->addDays(2)->addHour(),
+        ]);
+
+        $this->mentor->calendarEvents()->attach([$event1->getKey(), $event2->getKey()]);
+
+        $action = new ConfirmedCalendarEventsListPage;
+        $response = $action->handle($this->mentorProgram1);
+
+        expect($response)->toBeInstanceOf(Response::class);
+
+        $page = $response->toResponse(request())->getOriginalContent()->getData()['page'];
+        $props = $page['props'];
+
+        expect($props['calendarEvents'])->toHaveKey('Program A')
+            ->and($props['calendarEvents'])->not->toHaveKey('Program B');
+
+        $allEvents = collect($props['calendarEvents'])->flatten(1);
+        expect($allEvents)->toHaveCount(1);
+    });
+
+    it('does not filter when no mentor program provided', function (): void {
+        $event1 = CalendarEvent::factory()->create([
+            'mentor_program_id' => $this->mentorProgram1->getKey(),
+            'status'            => CalendarEventStatusEnum::CONFIRMED->value,
+            'start_date_time'   => Date::now()->addDay(),
+            'end_date_time'     => Date::now()->addDay()->addHour(),
+        ]);
+
+        $event2 = CalendarEvent::factory()->create([
+            'mentor_program_id' => $this->mentorProgram2->getKey(),
+            'status'            => CalendarEventStatusEnum::CONFIRMED->value,
+            'start_date_time'   => Date::now()->addDays(2),
+            'end_date_time'     => Date::now()->addDays(2)->addHour(),
+        ]);
+
+        $this->mentor->calendarEvents()->attach([$event1->getKey(), $event2->getKey()]);
+
+        $action = new ConfirmedCalendarEventsListPage;
+        $response = $action->handle();
+
+        expect($response)->toBeInstanceOf(Response::class);
+
+        $page = $response->toResponse(request())->getOriginalContent()->getData()['page'];
+        $props = $page['props'];
+
+        // Should return ALL events when null is passed (no filtering)
+        $allEvents = collect($props['calendarEvents'])->flatten(1);
+        expect($allEvents)->toHaveCount(3); // 2 new + 1 from beforeEach
+    });
+
+    it('orders events by start_date_time ascending', function (): void {
+        $laterEvent = CalendarEvent::factory()->create([
+            'mentor_program_id' => $this->mentorProgram1->getKey(),
+            'status'            => CalendarEventStatusEnum::CONFIRMED->value,
+            'start_date_time'   => Date::now()->addDays(5),
+            'end_date_time'     => Date::now()->addDays(5)->addHour(),
+        ]);
+
+        $earlierEvent = CalendarEvent::factory()->create([
+            'mentor_program_id' => $this->mentorProgram1->getKey(),
+            'status'            => CalendarEventStatusEnum::CONFIRMED->value,
+            'start_date_time'   => Date::now()->addDays(2),
+            'end_date_time'     => Date::now()->addDays(2)->addHour(),
+        ]);
+
+        $this->mentor->calendarEvents()->attach([$laterEvent->getKey(), $earlierEvent->getKey()]);
+
+        $action = new ConfirmedCalendarEventsListPage;
+        $response = $action->handle();
+
+        expect($response)->toBeInstanceOf(Response::class);
+
+        $page = $response->toResponse(request())->getOriginalContent()->getData()['page'];
+        $props = $page['props'];
+
+        $programAEvents = $props['calendarEvents']['Program A'];
+
+        // Earlier event should come before later event
+        expect($programAEvents[0]['id'])->toBe($earlierEvent->getKey())
+            ->and($programAEvents[1]['id'])->toBe($laterEvent->getKey());
+    });
+});

--- a/tests/Unit/Actions/Pages/Calendar/ConfirmedCalendarEventsListPageTest.php
+++ b/tests/Unit/Actions/Pages/Calendar/ConfirmedCalendarEventsListPageTest.php
@@ -55,10 +55,12 @@ describe('ConfirmedCalendarEventsListPage (Unit)', function (): void {
         expect($response)->toBeInstanceOf(Response::class);
 
         $page = $response->toResponse(request())->getOriginalContent()->getData()['page'];
+        $programKey = $this->program->getKey();
+
         expect($page['component'])->toBe('Calendar/ListConfirmedCalendarEventsPage')
             ->and($page['props'])->toHaveKeys(['locale', 'calendarEvents'])
-            ->and($page['props']['calendarEvents'])->toHaveKey('1')
-            ->and($page['props']['calendarEvents']['1']['name'])->toBe('Program X');
+            ->and($page['props']['calendarEvents'])->toHaveKey($programKey)
+            ->and($page['props']['calendarEvents'][$programKey]['name'])->toBe('Program X');
     });
 
     it('only includes confirmed events in the future', function (): void {

--- a/tests/Unit/Actions/Pages/Calendar/ConfirmedCalendarEventsListPageTest.php
+++ b/tests/Unit/Actions/Pages/Calendar/ConfirmedCalendarEventsListPageTest.php
@@ -57,7 +57,8 @@ describe('ConfirmedCalendarEventsListPage (Unit)', function (): void {
         $page = $response->toResponse(request())->getOriginalContent()->getData()['page'];
         expect($page['component'])->toBe('Calendar/ListConfirmedCalendarEventsPage')
             ->and($page['props'])->toHaveKeys(['locale', 'calendarEvents'])
-            ->and($page['props']['calendarEvents'])->toHaveKey('Program X');
+            ->and($page['props']['calendarEvents'])->toHaveKey('1')
+            ->and($page['props']['calendarEvents']['1']['name'])->toBe('Program X');
     });
 
     it('only includes confirmed events in the future', function (): void {
@@ -97,14 +98,13 @@ describe('ConfirmedCalendarEventsListPage (Unit)', function (): void {
         $props = $page['props'];
 
         // Should have Program X (from beforeEach) and Program A (future confirmed)
-        $allEvents = collect($props['calendarEvents'])->flatten(1);
+        $allEvents = collect($props['calendarEvents'][$this->mentorProgram1->getKey()]['events']);
 
         // The past and pending events should be excluded
         $eventIds = $allEvents->pluck('id')->toArray();
         expect($eventIds)->not->toContain($pastEvent->getKey())
             ->and($eventIds)->not->toContain($pendingEvent->getKey())
-            ->and($eventIds)->toContain($futureEvent->getKey())
-            ->and($eventIds)->toContain($this->event->getKey());
+            ->and($eventIds)->toContain($futureEvent->getKey());
     });
 
     it('groups events by mentor program name', function (): void {
@@ -132,10 +132,10 @@ describe('ConfirmedCalendarEventsListPage (Unit)', function (): void {
         $page = $response->toResponse(request())->getOriginalContent()->getData()['page'];
         $props = $page['props'];
 
-        expect($props['calendarEvents'])->toHaveKey('Program A')
-            ->and($props['calendarEvents']['Program A'])->toHaveCount(2);
+        expect($props['calendarEvents'][$this->mentorProgram1->getKey()]['name'])->toBe('Program A')
+            ->and($props['calendarEvents'][$this->mentorProgram1->getKey()]['events'])->toHaveCount(2);
 
-        foreach ($props['calendarEvents']['Program A'] as $event) {
+        foreach ($props['calendarEvents'][$this->mentorProgram1->getKey()]['events'] as $event) {
             expect($event['mentor_program_id'])->toBe($this->mentorProgram1->getKey());
         }
     });
@@ -165,10 +165,10 @@ describe('ConfirmedCalendarEventsListPage (Unit)', function (): void {
         $page = $response->toResponse(request())->getOriginalContent()->getData()['page'];
         $props = $page['props'];
 
-        expect($props['calendarEvents'])->toHaveKey('Program A')
-            ->and($props['calendarEvents'])->not->toHaveKey('Program B');
+        expect($props['calendarEvents'][$this->mentorProgram1->getKey()]['name'])->toBe('Program A')
+            ->and($props['calendarEvents'])->not->toHaveKey($this->mentorProgram2->getKey());
 
-        $allEvents = collect($props['calendarEvents'])->flatten(1);
+        $allEvents = collect($props['calendarEvents'][$this->mentorProgram1->getKey()]['events']);
         expect($allEvents)->toHaveCount(1);
     });
 
@@ -198,7 +198,7 @@ describe('ConfirmedCalendarEventsListPage (Unit)', function (): void {
         $props = $page['props'];
 
         // Should return ALL events when null is passed (no filtering)
-        $allEvents = collect($props['calendarEvents'])->flatten(1);
+        $allEvents = collect($props['calendarEvents']);
         expect($allEvents)->toHaveCount(3); // 2 new + 1 from beforeEach
     });
 
@@ -227,7 +227,7 @@ describe('ConfirmedCalendarEventsListPage (Unit)', function (): void {
         $page = $response->toResponse(request())->getOriginalContent()->getData()['page'];
         $props = $page['props'];
 
-        $programAEvents = $props['calendarEvents']['Program A'];
+        $programAEvents = $props['calendarEvents'][$this->mentorProgram1->getKey()]['events'];
 
         // Earlier event should come before later event
         expect($programAEvents[0]['id'])->toBe($earlierEvent->getKey())

--- a/tests/Unit/Enums/MentorSessionDurationOptionsEnumTest.php
+++ b/tests/Unit/Enums/MentorSessionDurationOptionsEnumTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\MentorSessionDurationOptionsEnum;
+
+mutates(MentorSessionDurationOptionsEnum::class);
+
+describe('MentorSessionDurationOptionsEnum', function (): void {
+    it('returns all names and values', function (): void {
+        $names = MentorSessionDurationOptionsEnum::names();
+        $values = MentorSessionDurationOptionsEnum::values();
+
+        $caseNames = array_map(fn (MentorSessionDurationOptionsEnum $case) => $case->name, MentorSessionDurationOptionsEnum::cases());
+        $caseValues = array_map(fn (MentorSessionDurationOptionsEnum $case) => $case->value, MentorSessionDurationOptionsEnum::cases());
+
+        expect($names)->toEqual($caseNames)
+            ->and($values)->toEqual($caseValues)
+            ->and(array_unique($names))->toHaveCount(count($names))
+            ->and(array_unique($values))->toHaveCount(count($values))
+            ->and($names)->each->not->toBeEmpty()
+            ->and($values)->each->toBeGreaterThan(0);
+    });
+
+    it('contains required duration options', function (): void {
+        expect(MentorSessionDurationOptionsEnum::values())
+            ->toContain(15)
+            ->toContain(30)
+            ->toContain(45)
+            ->toContain(60)
+            ->toContain(90)
+            ->toContain(120);
+    });
+});

--- a/tests/Unit/Enums/MentorSessionTypeEnumTest.php
+++ b/tests/Unit/Enums/MentorSessionTypeEnumTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\MentorSessionTypeEnum;
+
+mutates(MentorSessionTypeEnum::class);
+
+describe('MentorSessionTypeEnum', function (): void {
+    it('returns all names and values', function (): void {
+        $names = MentorSessionTypeEnum::names();
+        $values = MentorSessionTypeEnum::values();
+
+        $caseNames = array_map(fn (MentorSessionTypeEnum $case) => $case->name, MentorSessionTypeEnum::cases());
+        $caseValues = array_map(fn (MentorSessionTypeEnum $case) => $case->value, MentorSessionTypeEnum::cases());
+
+        expect($names)->toEqual($caseNames)
+            ->and($values)->toEqual($caseValues)
+            ->and(array_unique($names))->toHaveCount(count($names))
+            ->and(array_unique($values))->toHaveCount(count($values))
+            ->and($names)->each->not->toBeEmpty()
+            ->and($values)->each->not->toBeEmpty();
+    });
+
+    it('contains required session types', function (): void {
+        expect(MentorSessionTypeEnum::values())
+            ->toContain('Video Session')
+            ->toContain('Voice Session')
+            ->toContain('Code Review');
+    });
+});


### PR DESCRIPTION
## Що змінено

Додавання списку менторів в навігаційну панель

Можливість переходу на сторінку бронюваня зі списку менторів

Feature tests для відображення списку менторів тв букінгів

## Навіщо

Апдейт поточної логіки для бронювання подій

## Як перевірити

1) Відображає кнопку в  навігації на список менторів 
2) Дозволяє перейти на календар бронювання консултації в списку менторів та в профілі ментора

closes issue #159 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Перегляд підтверджених майбутніх подій календаря, згрупованих за програмою; нова сторінка та компонент для їх відображення.
  * Сторінка списку менторів з пагінацією, картками профілів, умовними посиланнями «Book Consultation» та доданим mainProgramSlug у профілі.
  * Додано опції сесій (типи та тривалості) і новий елемент навігації «Mentors».
  * Позначення основної програми (is_main) з міграцією, фабрикою та автоматичним встановленням першої програми як основної.

* **Bug Fixes**
  * Після збереження програми перенаправлення веде на список програм замість сторінки створення.

* **Documentation**
  * Повний довідник по системі бронювання календаря (docs/CALENDAR.md)

* **Tests**
  * Додані та оновлені тести для нових сторінок, енумів і пагінації/даних.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->