### PR TITLE
Fix OCTANE_SERVER default value to frankenphp

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,7 +68,7 @@ VITE_APP_NAME="${APP_NAME}"
 VITE_URL="${APP_URL}:5173"
 ASSET_URL="${APP_URL}"
 
-OCTANE_SERVER=swoole
+OCTANE_SERVER=frankenphp
 
 #Telescope
 TELESCOPE_PATH=telescope


### PR DESCRIPTION
The `.env.example` had `OCTANE_SERVER=swoole` but the project runs on FrankenPHP (documented in `docs/SETUP.md` and configured in Docker). This corrects the default so new developers don't accidentally start with the wrong server.